### PR TITLE
Update UIYabause.cpp

### DIFF
--- a/yabause/src/qt/ui/UIYabause.cpp
+++ b/yabause/src/qt/ui/UIYabause.cpp
@@ -938,7 +938,7 @@ void UIYabause::on_aToolsBackupManager_triggered()
 	YabauseLocker locker( mYabauseThread );
 	if ( mYabauseThread->init() < 0 )
 	{
-		CommonDialogs::information( QtYabause::translate( "Yabause is not initialized, can't manage backup ram." ) );
+		CommonDialogs::information( QtYabause::translate( "Kronos is not initialized, can't manage backup ram." ) );
 		return;
 	}
 	UIBackupRam( this ).exec();


### PR DESCRIPTION
Remplacement de Yabause par Kronos sur cette chaîne CommonDialogs::information( QtYabause::translate( "Yabause is not initialized, can't manage backup ram." ) );