### PR TITLE
Fixed Typo's problem 

### DIFF
--- a/yabause/src/qt/ui/UISettings.cpp
+++ b/yabause/src/qt/ui/UISettings.cpp
@@ -99,7 +99,7 @@ const Items mResolutionMode = Items()
 	<< Item("4", "4x");
 
 const Items mAspectRatio = Items()
-	<< Item("0", "Orginal aspect ratio")
+	<< Item("0", "Original aspect ratio")
 	<< Item("1", "Stretch to window");
 
 UISettings::UISettings(QList <translation_struct> *translations, QWidget* p )


### PR DESCRIPTION
Correction d'une faute d'orthographe pour la nouvelle option : Orginal aspect ratio --> Original aspect ratio