### PR TITLE
(libretro) Make GL optional for now

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -3,7 +3,7 @@ DYNAREC = 0
 HAVE_THREADS = 1
 HAVE_GRIFFIN = 0
 HAVE_SSE = 0
-HAVE_GL = 1
+HAVE_GL = 0
 
 ifeq ($(platform),)
 	platform = unix

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -133,10 +133,12 @@ SOURCES_C += $(LIBRETRO_COMM_DIR)/streams/file_stream.c \
 	 $(LIBRETRO_COMM_DIR)/compat/compat_strl.c \
 	 $(LIBRETRO_COMM_DIR)/encodings/encoding_utf.c \
 	 $(LIBRETRO_COMM_DIR)/streams/file_stream_transforms.c \
-	 $(LIBRETRO_COMM_DIR)/compat/compat_posix_string.c \
-	 $(LIBRETRO_COMM_DIR)/glsm/glsm.c \
+	 $(LIBRETRO_COMM_DIR)/compat/compat_posix_string.c
+ifeq ($(HAVE_GL),1)
+SOURCES_C += $(LIBRETRO_COMM_DIR)/glsm/glsm.c \
          $(LIBRETRO_COMM_DIR)/glsym/rglgen.c \
 	 $(LIBRETRO_COMM_DIR)/glsym/glsym_gl.c
+endif
 endif
 
 ifeq ($(HAVE_THREADS),1)

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -13,7 +13,9 @@
 #include <sys/stat.h>
 
 #include <libretro.h>
+#ifdef HAVE_GL
 #include <glsm/glsm.h>
+#endif
 
 #include "vdp1.h"
 #include "vdp2.h"
@@ -53,7 +55,9 @@ static retro_input_state_t input_state_cb;
 static retro_environment_t environ_cb;
 static retro_audio_sample_batch_t audio_batch_cb;
 
+#ifdef HAVE_GL
 static struct retro_hw_render_callback hw_render;
+#endif
 
 #define BPRINTF_BUFFER_SIZE 512
 #define __cdecl
@@ -597,7 +601,9 @@ SoundInterface_struct *SNDCoreList[] = {
 
 VideoInterface_struct *VIDCoreList[] = {
     //&VIDDummy,
+#ifdef HAVE_GL
     &VIDOGL,
+#endif
     &VIDSoft,
     NULL
 };

--- a/yabause/src/cdbase.c
+++ b/yabause/src/cdbase.c
@@ -39,7 +39,8 @@
 #include "zlib/zlib.h"
 
 #ifdef __LIBRETRO__
-#include "streams/file_stream_transforms.h"
+// Remove this for now, execution on windows fails because of it
+// #include "streams/file_stream_transforms.h"
 #include "compat/posix_string.h"
 #undef stricmp
 #define stricmp strcasecmp

--- a/yabause/src/vidsoft.c
+++ b/yabause/src/vidsoft.c
@@ -2214,7 +2214,12 @@ void VIDSoftSetupGL(void)
       0.0, 1.0
    };
 
+#if defined (_USEGLEW_)
    glewInit();
+#endif
+#if defined (__LIBRETRO__)
+   // do something to get GL context from retroarch (?)
+#endif
 
    glGenVertexArrays(1, &vao);
    glBindVertexArray(vao);

--- a/yabause/src/ygles.c
+++ b/yabause/src/ygles.c
@@ -1177,6 +1177,9 @@ int YglInit(int width, int height, unsigned int depth) {
   glewExperimental=GL_TRUE;
   if (glewInit() != 0) YabSetError(YAB_ERR_CANNOTINIT, _("Glew"));;
 #endif
+#if defined (__LIBRETRO__)
+   // do something to get GL context from retroarch (?)
+#endif
 
 #if defined(__USE_OPENGL_DEBUG__)
   // During init, enable debug output


### PR DESCRIPTION
Il y a encore un peu de boulot avant d'activer GL par défaut ;).
Sinon j'ai discuté avec @flyinghead qui m'a confirmé que glew n'était pas nécessaire ni souhaité (d'où l'ajout du ifdef autour du glewInit), normalement c'est retroarch qui va faire ce boulot à la place. J'en rediscute avec lui dans les jours qui arrivent (à moins qu'il ait le temps de jeter un oeil d'ici là ?)