### PR TITLE
fix lock on some intel gpus under windows

### DIFF
--- a/yabause/src/ygles.c
+++ b/yabause/src/ygles.c
@@ -2781,7 +2781,7 @@ static void waitVdp1End(int id) {
   if (_Ygl->syncVdp1[id] != 0) {
     while (end == 0) {
       int ret;
-      ret = glClientWaitSync(_Ygl->syncVdp1[id], 0, 20000000);
+      ret = glClientWaitSync(_Ygl->syncVdp1[id], GL_SYNC_FLUSH_COMMANDS_BIT, 0);
       if ((ret == GL_CONDITION_SATISFIED) || (ret == GL_ALREADY_SIGNALED)) end = 1;
     }
     glDeleteSync(_Ygl->syncVdp1[id]);
@@ -2796,7 +2796,6 @@ static void executeTMVDP1(int in, int out) {
     YglRenderVDP1();
     //YuiRevokeOGLOnThisThread();
     _Ygl->syncVdp1[in] = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE,0);
-    glFlush();
     YglReset(_Ygl->vdp1levels[out]);
     YglTmPull(YglTM_vdp1[out], 0);
     _Ygl->needVdp1Render = 0;

--- a/yabause/src/ygles.c
+++ b/yabause/src/ygles.c
@@ -2781,7 +2781,7 @@ static void waitVdp1End(int id) {
   if (_Ygl->syncVdp1[id] != 0) {
     while (end == 0) {
       int ret;
-      ret = glClientWaitSync(_Ygl->syncVdp1[id], GL_SYNC_FLUSH_COMMANDS_BIT, 0);
+      ret = glClientWaitSync(_Ygl->syncVdp1[id], GL_SYNC_FLUSH_COMMANDS_BIT, 20000000);
       if ((ret == GL_CONDITION_SATISFIED) || (ret == GL_ALREADY_SIGNALED)) end = 1;
     }
     glDeleteSync(_Ygl->syncVdp1[id]);

--- a/yabause/src/ygles.c
+++ b/yabause/src/ygles.c
@@ -2796,6 +2796,7 @@ static void executeTMVDP1(int in, int out) {
     YglRenderVDP1();
     //YuiRevokeOGLOnThisThread();
     _Ygl->syncVdp1[in] = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE,0);
+    glFlush();
     YglReset(_Ygl->vdp1levels[out]);
     YglTmPull(YglTM_vdp1[out], 0);
     _Ygl->needVdp1Render = 0;


### PR DESCRIPTION
Aucune idée des conséquences, mais d'après ce que je lis ailleurs (genre https://community.khronos.org/t/call-to-glclientwaitsync-blocks-forever/76577, https://community.khronos.org/t/glflush-or-glfinish-with-mulithreading/61309 ou https://stackoverflow.com/questions/33640702/opengl-glclientwaitsync-on-separate-thread), j'ai l'impression que c'est normal d’exécuter `glFlush` après `glFenceSync`.

Je pense en particulier qu'on est dans cette situation (https://www.opengl.org/registry/doc/glspec45.core.pdf) : 
> 4.1.2 Signaling
Footnote 3: The simple flushing behavior defined by SYNC_FLUSH_COMMANDS_BIT will not help when waiting for a fence command issued in another context’s command stream to complete. Applications which block on a fence sync object must take additional steps to assure that the context from which the corresponding fence command was issued has flushed that command to the graphics pipeline.

çà expliquerait pourquoi j'ai quelques éléments graphiques manquants malgré le déblocage.