### PR TITLE
Replace 'Can't initialize Kronos' by 'Can't initialize Kronos.' and '…

### DIFF
--- a/yabause/l10n/yabause_de.yts
+++ b/yabause/l10n/yabause_de.yts
@@ -93,7 +93,7 @@ Byte Write : %1 %2|Byte schreiben : %1 %2
 Cancel|Abbrechen
 Cannot initialize Windows SPTI Driver|Windows SPTI Treiber kann nicht initialisiert werden
 Can't plug in the new controller, cancelling.|Der neue Controller kann nicht angeschlossen werden. Der Vorgang wird abgebrochen
-Can't initialize Kronos|Kronos Kann nicht initialisiert werden
+Can't initialize Kronos.|Kronos Kann nicht initialisiert werden
 Cart/Memory|Wagen / Speicher			
 Cartridge|Cartridge
 CD Images (*.iso *.cue *.bin)|CD Image (*.iso *.cue *.bin)

--- a/yabause/l10n/yabause_default.yts
+++ b/yabause/l10n/yabause_default.yts
@@ -95,7 +95,7 @@ Byte Write : %1 %2|
 Cancel|
 Cannot initialize Windows SPTI Driver|
 Can't plug in the new controller, cancelling.|
-Can't initialize Kronos|
+Can't initialize Kronos.|
 Cart/Memory|
 Cartridge|
 CD Images (*.iso *.cue *.bin *.mds *.ccd *.zip)|

--- a/yabause/l10n/yabause_es.yts
+++ b/yabause/l10n/yabause_es.yts
@@ -93,7 +93,7 @@ Byte Write : %1 %2|Escritura de byte : %1 %2
 Cancel|Cancelar
 Cannot initialize Windows SPTI Driver|No se pudo inicializar el Driver SPTI de Windows
 Can't plug in the new controller, cancelling.|No se puede conectar el nuevo mando, cancelando.
-Can't initialize Kronos|No se pudo iniciar Kronos
+Can't initialize Kronos.|No se pudo iniciar Kronos
 Cart/Memory|Cartucho/Memoria
 Cartridge|Cartucho
 CD Images (*.iso *.cue *.bin)|Imágenes de CD (*.iso *.cue *.bin)

--- a/yabause/l10n/yabause_fr.yts
+++ b/yabause/l10n/yabause_fr.yts
@@ -95,7 +95,7 @@ Byte Write : %1 %2|Ecrire un Byte : %1 %2
 Cancel|Annuler
 Cannot initialize Windows SPTI Driver|Ne peut pas initialiser le pilote SPTI
 Can't plug in the new controller, cancelling.|Ne peut pas brancher dans le nouveau contrôleur, annuler.
-Can't initialize Kronos|Ne peut pas intialiser Kronos.
+Can't initialize Kronos.|Ne peut pas intialiser Kronos.
 Cart/Memory|Cartouche/Mémoire
 Cartridge|Cartouche :
 CD Images (*.iso *.cue *.bin *.mds *.ccd *.zip)|Images CD (*.iso *.cue *.bin *.mds *.ccd *.zip)

--- a/yabause/l10n/yabause_it.yts
+++ b/yabause/l10n/yabause_it.yts
@@ -92,7 +92,7 @@ Byte Write : %1 %2|
 Cancel|
 Cannot initialize Windows SPTI Driver|
 Can't plug in the new controller, cancelling.|
-Can't initialize Kronos|				
+Can't initialize Kronos.|				
 Cart/Memory|Cart/Memoria
 Cartridge|Cartuccia
 CD Images (*.iso *.cue *.bin *.mds *.ccd)|									  

--- a/yabause/src/qt/YabauseThread.cpp
+++ b/yabause/src/qt/YabauseThread.cpp
@@ -79,7 +79,7 @@ bool YabauseThread::pauseEmulation( bool pause, bool reset )
 
 	if ( mInit < 0 )
 	{
-		emit error( QtYabause::translate( "Can't initialize Yabause" ), false );
+		emit error( QtYabause::translate( "Can't initialize Kronos." ), false );
 		return false;
 	}
 


### PR DESCRIPTION
…Can't initialize Yabause' by Can't initialize Kronos.'