### PR TITLE
smpc: realign this condition with older code

### DIFF
--- a/yabause/src/sys/smpc/src/smpc.c
+++ b/yabause/src/sys/smpc/src/smpc.c
@@ -705,7 +705,7 @@ static void SmpcSetTiming(void) {
          SmpcInternalVars->timing = 1; // this has to be tested on a real saturn
          return;
       case 0x10:
-          if (SmpcInternalVars->firstPeri != 0) {
+          if (SmpcInternalVars->firstPeri == 1) {
             SmpcInternalVars->timing = 16000;
             intback_wait_for_line = 1;
           } else {


### PR DESCRIPTION
Semble cohérent vis à vis du codepath pre-https://github.com/FCare/Kronos/commit/e34d30e867742951bff27466deff6b77930501ca , à l'époque on ne rentrait dans cette condition que si `SmpcInternalVars->firstPeri` était égal à 1 (à l'époque `SmpcInternalVars->intback`, mais c'est la même chose), hors une valeur actuelle de 2 pour cette variable donnerait une valeur de 0 dans l'ancien codepath, on ne rentrerait donc pas dans cette condition.

Pour la condition restante (ligne 794), même si le même raisonnement pourrait s'appliquer, je pense que l'on doit la laisser telle quelle (jusqu'à preuve du contraire), la raison : cette notion de `SmpcInternalVars->firstPeri` incrémenté à 2 semble être du [backport de mame](https://github.com/mamedev/mame/blob/master/src/devices/machine/smpc.cpp#L759-L768) dans le cadre de la stv, hors dans le [code équivalent à la ligne 794 sur mame](https://github.com/mamedev/mame/blob/master/src/devices/machine/smpc.cpp#L352), on rentre bien dans cette condition dès que `SmpcInternalVars->firstPeri` est différent de 0. 

Ce changement permet à Assault Suit Leynos 2 de boot chez moi, sans entraîner de nouvelles régressions sur les autres jeux testés hier et aujourd'hui (Sega Rally, Daytona USA, Alone in the dark, Rayman, Batman), j'ai également testé de manière assez exhaustive la stv vu que ces changements étaient liés, je n'ai pas vu de régression sur la dizaine de jeux testés, y compris sur les fonctionnalités un peu spécifique type eeprom. 