### PR TITLE
Fix -mfpmath=sse requiring -msse depending on your GCC configuration

### DIFF
--- a/yabause/src/libretro/Makefile
+++ b/yabause/src/libretro/Makefile
@@ -262,7 +262,7 @@ ifeq ($(__USE_OPENGL_DEBUG__),1)
 endif
 
 ifeq ($(HAVE_SSE),1)
-	FLAGS += -mfpmath=sse
+	FLAGS += -msse -mfpmath=sse
 endif
 
 ifeq ($(DEBUG_ASAN), 1)


### PR DESCRIPTION
libretro Makefile is incorrect, you need to explicitely specify -msse when using -mfpmath=sse if your GCC configuration is targeting older archs like i586 or i686

Without that GCC (depending on your GCC build configuration) might output this warning :
warning sse instruction set disabled using 387 arithmetics

This is useful especially when building through cross-compiler and/or buildroot