### PR TITLE
System language change functionality

### DIFF
--- a/yabause/src/ctrl/src/yabause.c
+++ b/yabause/src/ctrl/src/yabause.c
@@ -119,6 +119,7 @@ void print_usage(const char *program_name) {
           "Usage: %s [OPTIONS]...\n", program_name);
    printf("   -h         --help                 Print help and exit\n");
    printf("   -b STRING  --bios=STRING          bios file\n");
+   printf("   -l STRING  --language=STRING      english, deutsch, french, spanish,\n                                     italian, japanese\n");
    printf("   -i STRING  --iso=STRING           iso/cue file\n");
    printf("   -c STRING  --cdrom=STRING         cdrom path\n");
    printf("   -ns        --nosound              turn sound off\n");

--- a/yabause/src/port/linux/main.c
+++ b/yabause/src/port/linux/main.c
@@ -142,6 +142,11 @@ static char stvbiospath[256] = "\0";
 
 yabauseinit_struct yinit;
 
+char* toLower(char* s) {
+  for(char *p=s; *p; p++) *p=tolower(*p);
+  return s;
+}
+
 void YuiMsg(const char *format, ...) {
   va_list arglist;
   va_start( arglist, format );
@@ -196,6 +201,7 @@ void YuiInit() {
 	yinit.cdcoretype = CDCORE_DEFAULT;
 	yinit.carttype = CART_DRAM32MBIT;
 	yinit.regionid = REGION_EUROPE;
+	yinit.languageid = 0;
 	yinit.biospath = NULL;
 	yinit.cdpath = NULL;
 	yinit.buppath = "./bup.ram";
@@ -265,6 +271,24 @@ int main(int argc, char *argv[]) {
       } else if (strstr(argv[i], "--bios=")) {
         strncpy(biospath, argv[i] + strlen("--bios="), 256);
         yinit.biospath = biospath;
+      }
+      //set System Language
+      if (0 == strcmp(argv[i], "-l") && argv[i + 1]) {
+        strncpy(strsyslangeid, argv[i + 1], 256);
+        if (toLower(strsyslangeid) == "english") { yinit.languageid = 0; }
+        if (toLower(strsyslangeid) == "deutsch") { yinit.languageid = 1; }
+        if (toLower(strsyslangeid) == "french") { yinit.languageid = 2; }
+        if (toLower(strsyslangeid) == "spanish") { yinit.languageid = 3; }
+        if (toLower(strsyslangeid) == "italian") { yinit.languageid = 4; }
+        if (toLower(strsyslangeid) == "japanese") { yinit.languageid = 5; }
+      } else if (strstr(argv[i], "--language=")) {
+        strncpy(strsyslangeid, argv[i] + strlen("--language="), 256);
+        if (toLower(strsyslangeid) == "english") { yinit.languageid = 0; }
+        if (toLower(strsyslangeid) == "deutsch") { yinit.languageid = 1; }
+        if (toLower(strsyslangeid) == "french") { yinit.languageid = 2; }
+        if (toLower(strsyslangeid) == "spanish") { yinit.languageid = 3; }
+        if (toLower(strsyslangeid) == "italian") { yinit.languageid = 4; }
+        if (toLower(strsyslangeid) == "japanese") { yinit.languageid = 5; }
       }
       //set iso
       else if (0 == strcmp(argv[i], "-i") && argv[i + 1]) {

--- a/yabause/src/port/linux/main_test.c
+++ b/yabause/src/port/linux/main_test.c
@@ -129,6 +129,7 @@ void YuiInit() {
 	yinit.cdcoretype = CDCORE_DEFAULT;
 	yinit.carttype = 0;
 	yinit.regionid = REGION_EUROPE;
+	yinit.languageid = 0;
 	yinit.biospath = NULL;
 	yinit.cdpath = NULL;
 	yinit.buppath = NULL;

--- a/yabause/src/port/qt/Arguments.cpp
+++ b/yabause/src/port/qt/Arguments.cpp
@@ -23,6 +23,7 @@ namespace Arguments
 	void autostart(const QString& param);
 	void binary(const QString& param);
 	void bios(const QString& param);
+	void syslangid(const QString& param);
 	void cdrom(const QString& param);
 	void fullscreen(const QString& param);
 	void help(const QString& param);
@@ -50,6 +51,7 @@ namespace Arguments
 		{ "-a",  "--autostart", NULL,       "Automatically start emulation.",                      1, autostart },
 		{ NULL,  "--binary=", "<FILE>[:ADDRESS]", "Use a binary file.",                           1, binary },
 		{ "-b",  "--bios=", "<BIOS>",       "Choose a bios file.",                                3, bios },
+		{ "-l",  "--language=", "<language>","Choose the system language: english, deutsch, french, spanish, italian, japanese",                     7, syslangid },
 		{ "-c",  "--cdrom=", "<CDROM>",     "Choose the cdrom device.",                           4, cdrom },
 		{ "-f",  "--fullscreen", NULL,      "Start the emulator in fullscreen.",                  5, fullscreen },
 		{ "-h",  "--help", NULL,            "Show this help and exit.",                           0, help },
@@ -62,8 +64,8 @@ namespace Arguments
 
 	void parse()
 	{
-		QVector<Option *> choosenOptions(7);
-		QVector<QString> params(7);
+		QVector<Option *> choosenOptions(8);
+		QVector<QString> params(8);
 
 		QStringList arguments = QApplication::arguments();
 		QStringListIterator argit(arguments);
@@ -90,7 +92,7 @@ namespace Arguments
 			}
 		}
 
-		for(int i = 0;i < 7;i++)
+		for(int i = 0;i < 8;i++)
 		{
 			Option * option = choosenOptions[i];
 			if (option)
@@ -140,6 +142,17 @@ namespace Arguments
 		vs->setValue("General/Bios", param);
 	}
 
+	void syslangid(const QString& param)
+	{
+		VolatileSettings * vs = QtYabause::volatileSettings();
+		if (param.toLower() == "english") { vs->setValue("General/SystemLanguageID", 0); }
+		if (param.toLower() == "deutsch") { vs->setValue("General/SystemLanguageID", 1); }
+		if (param.toLower() == "french") { vs->setValue("General/SystemLanguageID", 2); }
+		if (param.toLower() == "spanish") { vs->setValue("General/SystemLanguageID", 3); }
+		if (param.toLower() == "italian") { vs->setValue("General/SystemLanguageID", 4); }
+		if (param.toLower() == "japanese") { vs->setValue("General/SystemLanguageID", 5); }
+	}
+	
 	void cdrom(const QString& param)
 	{
 		VolatileSettings * vs = QtYabause::volatileSettings();

--- a/yabause/src/port/qt/YabauseThread.cpp
+++ b/yabause/src/port/qt/YabauseThread.cpp
@@ -367,6 +367,21 @@ void YabauseThread::reloadSettings()
 			default : mYabauseConf.stv_favorite_region = 1; break;
 		}
 	}
+	const QString r1 = vs->value( "General/SystemLanguageID", mYabauseConf.languageid ).toString();
+	if ( r1.isEmpty() || r1 == "" )
+		mYabauseConf.languageid = 0;
+	else
+	{
+		switch ( r1[0].toLatin1() )
+		{
+			case '0': mYabauseConf.languageid = 0; break;
+			case '1': mYabauseConf.languageid = 1; break;
+			case '2': mYabauseConf.languageid = 2; break;
+			case '3': mYabauseConf.languageid = 3; break;
+			case '4': mYabauseConf.languageid = 4; break;
+			case '5': mYabauseConf.languageid = 5; break;
+		}
+	}
 	if (vs->value("General/EnableEmulatedBios", false).toBool())
 		mYabauseConf.biospath = strdup( "" );
 	else
@@ -445,6 +460,7 @@ void YabauseThread::resetYabauseConf()
 	mYabauseConf.cdcoretype = QtYabause::defaultCDCore().id;
 	mYabauseConf.carttype = CART_NONE;
 	mYabauseConf.regionid = 0;
+	mYabauseConf.languageid = 0;
 	mYabauseConf.biospath = 0;
 	mYabauseConf.cdpath = 0;
 	mYabauseConf.buppath = 0;

--- a/yabause/src/port/qt/ui/UISettings.cpp
+++ b/yabause/src/port/qt/ui/UISettings.cpp
@@ -55,6 +55,14 @@ struct Item
 
 typedef QList<Item> Items;
 
+const Items mSysLanguageID = Items()
+	<< Item( "0", "English" )
+	<< Item( "1", "Deutsch" )
+	<< Item( "2", "French" )
+	<< Item( "3", "Spanish" )
+	<< Item( "4", "Italian" )
+	<< Item( "5", "Japanese" );
+
 const Items mRegions = Items()
   << Item( "E", "Europe (PAL)" )
 	<< Item( "U", "North America (NTSC)" )
@@ -528,6 +536,10 @@ void UISettings::loadCores()
 	foreach ( const Item& it, mRegions )
 		cbRegion->addItem( QtYabause::translate( it.Name ), it.id );
 
+	// System Language
+	foreach ( const Item& it, mSysLanguageID  )
+		cbSysLanguageID ->addItem( QtYabause::translate( it.Name ), it.id );
+	
 	// SH2 Interpreters
 	for ( int i = 0; SH2CoreList[i] != NULL; i++ )
 		cbSH2Interpreter->addItem( QtYabause::translate( SH2CoreList[i]->Name ), SH2CoreList[i]->id );
@@ -602,6 +614,7 @@ void UISettings::loadSettings()
 		cbCdDrive->setCurrentIndex(leCdRom->text().isEmpty() ? 0 : cbCdDrive->findText(leCdRom->text()));
 
 	leSaveStates->setText( s->value( "General/SaveStates", getDataDirPath() ).toString() );
+	cbSysLanguageID->setCurrentIndex( cbSysLanguageID->findData( s->value( "General/SystemLanguageID", mSysLanguageID.at( 0 ).id ).toString() ) );
 #ifdef HAVE_LIBMINI18N
 	int i;
 	if ((i=cbTranslation->findData(s->value( "General/Translation" ).toString())) != -1)
@@ -698,6 +711,7 @@ void UISettings::saveSettings()
 	else
 		s->setValue( "General/CdRomISO", leCdRom->text() );
 	s->setValue( "General/SaveStates", leSaveStates->text() );
+	s->setValue( "General/SystemLanguageID", cbSysLanguageID->itemData( cbSysLanguageID->currentIndex() ).toString() );
 #ifdef HAVE_LIBMINI18N
 	s->setValue( "General/Translation", cbTranslation->itemData(cbTranslation->currentIndex()).toString() );
 #endif

--- a/yabause/src/port/qt/ui/UISettings.ui
+++ b/yabause/src/port/qt/ui/UISettings.ui
@@ -117,6 +117,25 @@
         </widget>
        </item>
        <item row="10" column="0" colspan="2">
+	<widget class="QLabel" name="lSysLanguageID">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>System Language</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0" colspan="2">
+        <widget class="QComboBox" name="cbSysLanguageID"/>
+       </item>
+       <item row="12" column="0" colspan="2">
         <widget class="QLabel" name="lTranslation">
          <property name="font">
           <font>
@@ -186,7 +205,7 @@
          </property>
         </widget>
        </item>
-       <item row="11" column="0" colspan="2">
+       <item row="13" column="0" colspan="2">
         <widget class="QComboBox" name="cbTranslation"/>
        </item>
        <item row="20" column="0">

--- a/yabause/src/port/qt/ui/UIYabause.cpp
+++ b/yabause/src/port/qt/ui/UIYabause.cpp
@@ -541,6 +541,7 @@ void UIYabause::on_aFileSettings_triggered()
          newhash["Advanced/68kCore"] != hash["Advanced/68kCore"] ||
 			newhash["General/CdRom"]!=hash["General/CdRom"] ||
 			newhash["General/CdRomISO"]!=hash["General/CdRomISO"] ||
+		        newhash["General/SystemLanguageID"]!=hash["General/SystemLanguageID"] ||
 			newhash["General/ClockSync"]!=hash["General/ClockSync"] ||
 			newhash["General/FixedBaseTime"]!=hash["General/FixedBaseTime"]
 		)


### PR DESCRIPTION
Hello,

I offer this small contribution to allow changing the system language from the bios settings which is always in English after each start of the emulation.

With this modification, it is now possible to change the language from the "-l" or "--language" command line, then the option can also be modified from the application settings and then saved in the configuration file.

Some games, like Rayman for example, do not allow you to select the language and are based on the language configuration from the system settings. This can be annoying if a player wants to play their game in their native language or of their choice.

Test performed on Linux. The code must be good for Windows also.

Hoping that this contribution can interest you because it brings a comfort during the game to the player.