### PR TITLE
fix misaligned address access

### DIFF
--- a/yabause/src/core/video/opengl/compute_shader/src/vidcs.c
+++ b/yabause/src/core/video/opengl/compute_shader/src/vidcs.c
@@ -219,7 +219,7 @@ void VIDCSVdp1NormalSpriteDraw(vdp1cmd_struct *cmd, u8 * ram, Vdp1 * regs, u8* b
 
   if (((cmd->CMDPMOD >> 3) & 0x7u) == 5) {
     // hard/vdp2/hon/p09_20.htm#no9_21
-    u32 *cclist = (u32 *)&(Vdp2Lines[0].CCRSA);
+    u16 *cclist = &(Vdp2Lines[0].CCRSA);
     cclist[0] &= 0x1Fu;
   }
   cmd->SPCTL = Vdp2Lines[0].SPCTL;
@@ -266,7 +266,7 @@ void VIDCSVdp1DistortedSpriteDraw(vdp1cmd_struct *cmd, u8 * ram, Vdp1 * regs, u8
 
   if (((cmd->CMDPMOD >> 3) & 0x7u) == 5) {
     // hard/vdp2/hon/p09_20.htm#no9_21
-    u32 *cclist = (u32 *)&(Vdp2Lines[0].CCRSA);
+    u16 *cclist = &(Vdp2Lines[0].CCRSA);
     cclist[0] &= 0x1Fu;
   }
   //gouraud


### PR DESCRIPTION
Sans conviction que ce soit le bon fix (il y avait peut-être une raison pour le cast en u32 ?), mais je suis tombé sur çà en utilisant UBSAN :
```
../core/video/opengl/compute_shader/src/vidcs.c:270:15: runtime error: load of misaligned address 0x7f4934c2571e for type 'u32', which requires 4 byte alignment
0x7f4934c2571e: note: pointer points here
 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 40 00  40 00 00 00 00 00 00 00  ef ff
             ^ 
../core/video/opengl/compute_shader/src/vidcs.c:270:15: runtime error: store to misaligned address 0x7f4934c2571e for type 'u32', which requires 4 byte alignment
0x7f4934c2571e: note: pointer points here
 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 40 00  40 00 00 00 00 00 00 00  ef ff
             ^ 
../core/video/opengl/compute_shader/src/vidcs.c:223:15: runtime error: load of misaligned address 0x7f4934c2571e for type 'u32', which requires 4 byte alignment
0x7f4934c2571e: note: pointer points here
 07 06 00 00 00 00  00 00 00 00 00 00 00 0d  00 00 00 00 00 00 4c 00  4f 00 00 00 00 00 00 00  f9 00
             ^ 
../core/video/opengl/compute_shader/src/vidcs.c:223:15: runtime error: store to misaligned address 0x7f4934c2571e for type 'u32', which requires 4 byte alignment
0x7f4934c2571e: note: pointer points here
 07 06 00 00 00 00  00 00 00 00 00 00 00 0d  00 00 00 00 00 00 4c 00  4f 00 00 00 00 00 00 00  f9 00
             ^ 
```