### PR TITLE
fix https://github.com/rob-ack/yabause/issues/12:

### DIFF
--- a/yabause/src/port/qt/ui/UICheatSearch.cpp
+++ b/yabause/src/port/qt/ui/UICheatSearch.cpp
@@ -305,7 +305,7 @@ void UICheatSearch::on_pbAddCheat_clicked()
          int cheatsCount;
          mCheats = CheatGetList( &cheatsCount );
 
-         CheatChangeDescriptionByIndex( cheatsCount -1, d.leDescription->text().toLatin1().data() );
+         CheatChangeDescriptionByIndex( cheatsCount -1, d.teDescription->toPlainText().toLatin1().data() );
       }
    }
 }


### PR DESCRIPTION
-use correct variable to get and sset cheat description

(cherry picked from commit d33982f21767d3689bb58d2b9574273f8e2dcfc2)