### PR TITLE
fix: perf for all games (burning rangers graphics fixed)

### DIFF
--- a/yabause/src/sys/vdp1/src/vdp1.c
+++ b/yabause/src/sys/vdp1/src/vdp1.c
@@ -1022,7 +1022,7 @@ void Vdp1DrawCommands(u8 * ram, Vdp1 * regs, u8* back_framebuffer)
 {
   int cylesPerLine  = getVdp1CyclesPerLine();
 
-  // if (CmdListDrawn != 0) return; //The command list has already been drawn for the current frame
+  if (CmdListDrawn != 0) return; //The command list has already been drawn for the current frame
 
   if (Vdp1External.status == VDP1_STATUS_IDLE) {
     returnAddr = 0xffffffff;


### PR DESCRIPTION
-burning rangers graphics glitches and horrible performance.
-generally this will improve performance on all gmaes

(cherry picked from commit 4b09b281c4aee75db30071c65ffdc902f3c537e0)

Before:
![image](https://user-images.githubusercontent.com/20187182/133985641-ea537a94-7628-4d89-b7f7-08eda44b1946.png)

After:
![image](https://user-images.githubusercontent.com/20187182/133985945-b71b3c96-0d1a-460b-923b-f7b2adc4d3fe.png)
