### PR TITLE
[cartridge] fix https://github.com/rob-ack/yabause/issues/16:

### DIFF
--- a/yabause/src/port/qt/QtYabause.cpp
+++ b/yabause/src/port/qt/QtYabause.cpp
@@ -650,3 +650,7 @@ void QtYabause::clearMouseBits()
    mPort1MouseBits.clear();
    mPort2MouseBits.clear();
 }
+
+QString QtYabause::DefaultPaths::Screenshots() { return getDataDirPath() + "/screenshots"; }
+
+QString QtYabause::DefaultPaths::Cartridge() { return getDataDirPath(); }

--- a/yabause/src/port/qt/QtYabause.h
+++ b/yabause/src/port/qt/QtYabause.h
@@ -71,6 +71,7 @@ extern "C"
 
 #include <QString>
 #include <QMap>
+#include <QDateTime>
 
 class UIYabause;
 class Settings;
@@ -85,6 +86,30 @@ typedef struct
 
 namespace QtYabause
 {
+	namespace SettingKeys
+	{
+		static constexpr char const* const ScreenshotsDirectory = "General/ScreenshotsDirectory";
+		static constexpr char const* const ScreenshotsFormat = "General/ScreenshotsFormat";
+	};
+
+	namespace VolatileSettingKeys
+	{
+		static constexpr char const* const CartridgePath = "Cartridge/Path";
+	};
+
+	namespace DefaultPaths
+	{
+		QString Screenshots();
+		QString Cartridge();
+	};
+
+	struct QtYabauseError
+	{
+		int ErrorType;
+		QString ErrorMessage;
+		QDateTime ErrorTimestamp = QDateTime::currentDateTime();
+	};
+
 	void appendLog( const char* str );
 	UIYabause* mainWindow( bool create = true );
 	Settings* settings( bool create = true );

--- a/yabause/src/port/qt/Settings.h
+++ b/yabause/src/port/qt/Settings.h
@@ -52,21 +52,6 @@ public:
 protected:
 	static QString mProgramName;
 	static QString mProgramVersion;
-
-public:
-
-	struct Keys
-	{
-		static constexpr char const* const ScreenshotsDirectory = "General/ScreenshotsDirectory";
-		static constexpr char const* const ScreenshotsFormat = "General/ScreenshotsFormat";
-		Keys() = delete;
-	};
-
-	struct DefaultPaths
-	{
-		inline static QString const Screenshots() { return getDataDirPath() + "/screenshots"; }
-		DefaultPaths() = delete;
-	};
 };
 
 #endif // PSETTINGS_H

--- a/yabause/src/port/qt/YabauseThread.cpp
+++ b/yabause/src/port/qt/YabauseThread.cpp
@@ -401,7 +401,7 @@ void YabauseThread::reloadSettings()
 	} else {
 		mYabauseConf.extend_backup = 0;
 	}
-	mYabauseConf.cartpath = strdup( vs->value( "Cartridge/Path", mYabauseConf.cartpath ).toString().toLatin1().constData() );
+	mYabauseConf.cartpath = strdup( vs->value(QtYabause::VolatileSettingKeys::CartridgePath, mYabauseConf.cartpath ).toString().toLatin1().constData() );
 	mYabauseConf.eepromdir = strcat(strdup( mYabauseConf.cartpath ), "/");
 	mYabauseConf.modemip = strdup( vs->value( "Cartridge/ModemIP", mYabauseConf.modemip ).toString().toLatin1().constData() );
 	mYabauseConf.modemport = strdup( vs->value( "Cartridge/ModemPort", mYabauseConf.modemport ).toString().toLatin1().constData() );

--- a/yabause/src/port/qt/ui/UISettings.h
+++ b/yabause/src/port/qt/ui/UISettings.h
@@ -25,6 +25,8 @@
 #include "../QtYabause.h"
 #include "UIYabause.h"
 
+#include <optional>
+
 QStringList getCdDriveList();
 
 class UISettings : public QDialog, public Ui::UISettings
@@ -38,10 +40,10 @@ protected:
 	QList <translation_struct> trans;
 	QList <QAction*> actionsList;
 
-	void requestFile( const QString& caption, QLineEdit* edit, const QString& filters = QString() );
-	void requestNewFile( const QString& caption, QLineEdit* edit, const QString& filters = QString() );
-	void requestFolder( const QString& caption, QLineEdit* edit );
-	void requestSTVFolder( const QString& caption, QLineEdit* edit );
+	void requestFile( const QString& caption, QLineEdit* edit, const QString& filters = QString(), std::optional<QString> proposedPath = std::optional<QString>());
+	void requestNewFile( const QString& caption, QLineEdit* edit, const QString& filters = QString(), std::optional<QString> proposedPath = std::optional<QString>());
+	void requestFolder( const QString& caption, QLineEdit* edit, std::optional<QString> proposedPath = std::optional<QString>());
+	void requestSTVFolder(const QString & caption, QLineEdit * edit, std::optional<QString> proposedPath = std::optional<QString>());
 	void setupCdDrives();
 	void loadCores();
 	void loadTranslations();
@@ -59,7 +61,7 @@ protected slots:
 	void on_cbClockSync_stateChanged( int state );
 	void on_cbCartridge_currentIndexChanged( int id );
 	void accept();
-        void changeResolution(int id);
+	void changeResolution(int id);
         void changeFilterMode(int id);
 				void changeVideoMode(int id);
         void changeUpscaleMode(int id);
@@ -70,6 +72,12 @@ protected slots:
 				void changeBandingMode(int id);
 				void changePolygonMode(int id);
 				void changeCSMode(int id);
+
+private:
+	QString getCartridgePathSettingsKey(std::optional<int> cartridgeType = std::optional<int>()) const;
+	void updateVolatileSettings() const;
+
+	int selectedCartridgeType = 0;
 };
 
 #endif // UISETTINGS_H

--- a/yabause/src/port/qt/ui/UISettings.ui
+++ b/yabause/src/port/qt/ui/UISettings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>513</width>
-    <height>723</height>
+    <height>751</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -634,84 +634,12 @@
        <string>Cart/Memory</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout3">
-       <item row="9" column="3">
-        <widget class="QToolButton" name="tbMemory">
+       <item row="4" column="0">
+        <widget class="QLabel" name="lCartridgeModemPort">
          <property name="text">
-          <string>...</string>
+          <string>Port</string>
          </property>
         </widget>
-       </item>
-       <item row="5" column="3">
-        <widget class="QToolButton" name="tbCartridge">
-         <property name="text">
-          <string>...</string>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="0" colspan="4">
-        <widget class="QLabel" name="lMemory">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Memory</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="0" colspan="4">
-        <widget class="QLabel" name="lMpegROM">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Mpeg ROM</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="0" colspan="3">
-        <widget class="QLineEdit" name="leMemory"/>
-       </item>
-       <item row="13" column="1">
-        <spacer>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>2</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="11" column="3">
-        <widget class="QToolButton" name="tbMpegROM">
-         <property name="text">
-          <string>...</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0" colspan="3">
-        <widget class="QLineEdit" name="leCartridge">
-         <property name="inputMask">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="0" colspan="3">
-        <widget class="QLineEdit" name="leMpegROM"/>
        </item>
        <item row="0" column="0" colspan="4">
         <widget class="QLabel" name="lCartridge">
@@ -729,6 +657,12 @@
          </property>
         </widget>
        </item>
+       <item row="2" column="0" colspan="4">
+        <widget class="QComboBox" name="cbSTVGame"/>
+       </item>
+       <item row="1" column="0" colspan="4">
+        <widget class="QComboBox" name="cbCartridge"/>
+       </item>
        <item row="2" column="2" colspan="2">
         <widget class="QLineEdit" name="leCartridgeModemIP">
          <property name="toolTip">
@@ -742,16 +676,26 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="0" colspan="4">
-        <widget class="QComboBox" name="cbCartridge"/>
-       </item>
-       <item row="2" column="0" colspan="4">
-        <widget class="QComboBox" name="cbSTVGame"/>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="lCartridgeModemIP">
+       <item row="9" column="0" colspan="4">
+        <widget class="QLabel" name="lMemory">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
          <property name="text">
-          <string>Default Dial IP</string>
+          <string>Memory</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="3">
+        <widget class="QToolButton" name="tbCartridge">
+         <property name="text">
+          <string>...</string>
          </property>
         </widget>
        </item>
@@ -768,21 +712,21 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="lCartridgeModemPort">
+       <item row="12" column="3">
+        <widget class="QToolButton" name="tbMpegROM">
          <property name="text">
-          <string>Port</string>
+          <string>...</string>
          </property>
         </widget>
        </item>
-       <item row="12" column="0">
-        <widget class="QCheckBox" name="checkBox_extended_internal_backup">
+       <item row="10" column="3">
+        <widget class="QToolButton" name="tbMemory">
          <property name="text">
-          <string>Extend Internal backup memory to 8MB</string>
+          <string>...</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
+       <item row="7" column="0">
         <widget class="QLabel" name="lRegion">
          <property name="font">
           <font>
@@ -798,8 +742,71 @@
          </property>
         </widget>
        </item>
-       <item row="7" column="0">
+       <item row="10" column="0" colspan="3">
+        <widget class="QLineEdit" name="leMemory"/>
+       </item>
+       <item row="14" column="1">
+        <spacer>
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>2</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="11" column="0" colspan="4">
+        <widget class="QLabel" name="lMpegROM">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Mpeg ROM</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="lCartridgeModemIP">
+         <property name="text">
+          <string>Default Dial IP</string>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="0" colspan="3">
+        <widget class="QLineEdit" name="leMpegROM"/>
+       </item>
+       <item row="13" column="0">
+        <widget class="QCheckBox" name="checkBox_extended_internal_backup">
+         <property name="text">
+          <string>Extend Internal backup memory to 8MB</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0">
         <widget class="QComboBox" name="cbRegion"/>
+       </item>
+       <item row="6" column="0" colspan="3">
+        <widget class="QLineEdit" name="leCartridge">
+         <property name="inputMask">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="lCartridgePath">
+         <property name="text">
+          <string>Cartridge Path</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -1156,8 +1163,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>373</x>
-     <y>399</y>
+     <x>382</x>
+     <y>741</y>
     </hint>
     <hint type="destinationlabel">
      <x>383</x>
@@ -1172,8 +1179,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>467</x>
-     <y>399</y>
+     <x>476</x>
+     <y>741</y>
     </hint>
     <hint type="destinationlabel">
      <x>453</x>
@@ -1183,7 +1190,7 @@
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="bgShowToolbar"/>
   <buttongroup name="bgShowMenubar"/>
+  <buttongroup name="bgShowToolbar"/>
  </buttongroups>
 </ui>

--- a/yabause/src/port/qt/ui/UIYabause.cpp
+++ b/yabause/src/port/qt/ui/UIYabause.cpp
@@ -720,8 +720,8 @@ void UIYabause::on_aFileScreenshot_triggered()
 	// take screenshot of gl view
 	QImage const screenshot = mYabauseGL->grabFramebuffer();
 
-	auto const directory = QtYabause::volatileSettings()->value(Settings::Keys::ScreenshotsDirectory, Settings::DefaultPaths::Screenshots()).toString();
-	auto const format = QtYabause::volatileSettings()->value(Settings::Keys::ScreenshotsFormat, "png").toString();
+	auto const directory = QtYabause::volatileSettings()->value(QtYabause::SettingKeys::ScreenshotsDirectory, QtYabause::DefaultPaths::Screenshots()).toString();
+	auto const format = QtYabause::volatileSettings()->value(QtYabause::SettingKeys::ScreenshotsFormat, "png").toString();
 
 	// request a file to save to to user
 	QString s = directory + "/" + fileInfo.baseName() + QString("_%1." + format).arg(QDateTime::currentDateTime().toString("dd_MM_yyyy-hh_mm_ss"));


### PR DESCRIPTION
-prompt the user if he changes the carriage settings to set up the cartridge path for each different type of cartridge if a path is needed. otherwise don't prompt and clear the path
-introduce proposed path to the user when he selects a new cartridge type
-auto select already existing paths if the user changes cartridge and the proposed path exists

this will prevent the user from unintendedly override its cartridge and provides more intuitive user support for the feature

(cherry picked from commit 104c04226ce46487f395dd2b70c75ba3ff15ee89)