### PR TITLE
Cherry-pick libchdr upstream commit to silence a compiler warning

### DIFF
--- a/yabause/src/tools/libchdr/src/chd.c
+++ b/yabause/src/tools/libchdr/src/chd.c
@@ -2339,10 +2339,6 @@ static chd_error zlib_codec_init(void *codec, uint32_t hunkbytes)
 	else
 		err = CHDERR_NONE;
 
-	/* handle an error */
-	if (err != CHDERR_NONE)
-		free(data);
-
 	return err;
 }
 


### PR DESCRIPTION
Original message:

```
Remove erroneous free() call in zlib_codec_init()

Remove a free() call inherited from the original MAME code
which allocated memory within zlib_codec_init(). It is no
longer appropriate to call here, as the data variable now
points to the middle of a caller-owned allocation.
```