### PR TITLE
Correct operator precedence

### DIFF
--- a/yabause/src/sys/vdp1/src/vdp1.c
+++ b/yabause/src/sys/vdp1/src/vdp1.c
@@ -82,7 +82,7 @@ static void checkFBSync();
 
 int CONVERTCMD(s32 *A) {
   s32 toto = (*A);
-  if ((((*A)>>12)&0x1)^(((*A)>>11)&0x1) != 0) {
+  if (((*A>>12 & 0x1) ^ (*A>>11 & 0x1)) != 0) {
     return 1;
   }
   if (((*A)>>11)&0x1) (*A) |= 0xF800;


### PR DESCRIPTION
This change is untested but it should work :)

In the previous version, != took precedence over ^ so that (((*A)>>11)&0x1) != 0 was evaluated first and then xored with the left hand side.

Here I remove all the unnecessary parens except the ones suggested by GCC -Wparentheses. And add the parens that are actually needed in order to evaluate !=0 last.