### PR TITLE
Consistently use _Ygl for width and height in libretro-specific code

### DIFF
--- a/yabause/src/core/video/opengl/compute_shader/src/yglcs.c
+++ b/yabause/src/core/video/opengl/compute_shader/src/yglcs.c
@@ -268,7 +268,7 @@ void VIDCSRender(Vdp2 *varVdp2Regs) {
     scale = MAX(w/_Ygl->rwidth, h/_Ygl->rheight);
 #else
   //Libretro is taking care to the resize
-  w = width;
+  w = _Ygl->width;
   h = _Ygl->height;
   x = y = 0;
 #endif


### PR DESCRIPTION
This fixes https://github.com/FCare/Kronos/issues/1562 for me.