### PR TITLE
Silence "implicit function declaration" warnings/errors

### DIFF
--- a/yabause/src/core/sh2/sh2_kronos/src/sh2int.c
+++ b/yabause/src/core/sh2/sh2_kronos/src/sh2int.c
@@ -339,12 +339,6 @@ static void outOfInt(SH2_struct *context) {
   executeLastPC(context);
 }
 
-int SH2KronosInterpreterDebugInit(void)
-{
-  int ret = SH2KronosInterpreterInit();
-  SH2SetExecSet(1);
-  return ret;
-}
 int SH2KronosInterpreterInit(void)
 {
 
@@ -445,6 +439,12 @@ int SH2KronosInterpreterInit(void)
    return 0;
 }
 
+int SH2KronosInterpreterDebugInit(void)
+{
+  int ret = SH2KronosInterpreterInit();
+  SH2SetExecSet(1);
+  return ret;
+}
 //////////////////////////////////////////////////////////////////////////////
 
 void SH2KronosInterpreterDeInit(void)

--- a/yabause/src/core/video/opengl/compute_shader/include/vdp1_compute.h
+++ b/yabause/src/core/video/opengl/compute_shader/include/vdp1_compute.h
@@ -77,6 +77,10 @@ extern void vdp1_compute_reset(void);
 extern void vdp1_update_banding(void);
 extern void vdp1_update_mesh(void);
 extern void vdp1_update_performance(void);
+extern void startVdp1Render(void);
+extern void startVdp1RenderUpscale(void);
+extern void endVdp1Render(void);
+extern void endVdp1RenderUpscale(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Move Debug version below the function that it calls so that the function is known.

Make the 4 shared functions extern.