### PR TITLE
Don't run ST-V init for Saturn discs

### DIFF
--- a/yabause/src/ctrl/src/yabause.c
+++ b/yabause/src/ctrl/src/yabause.c
@@ -276,11 +276,17 @@ int YabauseSh2Init(yabauseinit_struct *init)
       YabSetError(YAB_ERR_CANNOTINIT, _("Cartridge"));
       return -1;
    }
-   if (STVSingleInit(init->stvgamepath, init->stvbiospath, init->eepromdir, init->stv_favorite_region) != 0) {
-     if (STVInit(init->stvgame, init->cartpath, init->eepromdir, init->stv_favorite_region) != 0)
-     {
-       YabSetError(YAB_ERR_CANNOTINIT, _("STV emulation"));
-       return -1;
+   // Only an ST-V game carries these, and a Saturn disc has neither. Running it
+   // regardless fails for every Saturn game and takes the whole init down with
+   // it, since both calls refuse a null path and a null romset.
+   if (init->stvgamepath != NULL || init->stvgame != NULL)
+   {
+     if (STVSingleInit(init->stvgamepath, init->stvbiospath, init->eepromdir, init->stv_favorite_region) != 0) {
+       if (STVInit(init->stvgame, init->cartpath, init->eepromdir, init->stv_favorite_region) != 0)
+       {
+         YabSetError(YAB_ERR_CANNOTINIT, _("STV emulation"));
+         return -1;
+       }
      }
    }
 
@@ -398,11 +404,17 @@ TRACE_EMULATOR("YabauseInit");
       return -1;
    }
 
-   if (STVSingleInit(init->stvgamepath, init->stvbiospath, init->eepromdir, init->stv_favorite_region) != 0) {
-     if (STVInit(init->stvgame, init->cartpath, init->eepromdir, init->stv_favorite_region) != 0)
-     {
-       YabSetError(YAB_ERR_CANNOTINIT, _("STV emulation"));
-       return -1;
+   // Only an ST-V game carries these, and a Saturn disc has neither. Running it
+   // regardless fails for every Saturn game and takes the whole init down with
+   // it, since both calls refuse a null path and a null romset.
+   if (init->stvgamepath != NULL || init->stvgame != NULL)
+   {
+     if (STVSingleInit(init->stvgamepath, init->stvbiospath, init->eepromdir, init->stv_favorite_region) != 0) {
+       if (STVInit(init->stvgame, init->cartpath, init->eepromdir, init->stv_favorite_region) != 0)
+       {
+         YabSetError(YAB_ERR_CANNOTINIT, _("STV emulation"));
+         return -1;
+       }
      }
    }
 
@@ -561,11 +573,17 @@ static int YabauseRefreshInit(yabauseinit_struct *init) {
      return -1;
   }
 
-  if (STVSingleInit(init->stvgamepath, init->stvbiospath, init->eepromdir, init->stv_favorite_region) != 0) {
-    if (STVInit(init->stvgame, init->cartpath, init->eepromdir, init->stv_favorite_region) != 0)
-    {
-      YabSetError(YAB_ERR_CANNOTINIT, _("STV emulation"));
-      return -1;
+  // Only an ST-V game carries these, and a Saturn disc has neither. Running it
+  // regardless fails for every Saturn game and takes the whole init down with
+  // it, since both calls refuse a null path and a null romset.
+  if (init->stvgamepath != NULL || init->stvgame != NULL)
+  {
+    if (STVSingleInit(init->stvgamepath, init->stvbiospath, init->eepromdir, init->stv_favorite_region) != 0) {
+      if (STVInit(init->stvgame, init->cartpath, init->eepromdir, init->stv_favorite_region) != 0)
+      {
+        YabSetError(YAB_ERR_CANNOTINIT, _("STV emulation"));
+        return -1;
+      }
     }
   }
 


### PR DESCRIPTION
Saturn discs fail to init because the ST-V path runs for them unconditionally.

`YabauseSh2Init()`, `YabauseFullInit()` and `YabauseRefreshInit()` each call
`STVSingleInit()` and then `STVInit()` with no check that there is an ST-V game
to init:

```c
if (STVSingleInit(init->stvgamepath, init->stvbiospath, init->eepromdir, init->stv_favorite_region) != 0) {
  if (STVInit(init->stvgame, init->cartpath, init->eepromdir, init->stv_favorite_region) != 0)
  {
    YabSetError(YAB_ERR_CANNOTINIT, _("STV emulation"));
    return -1;
  }
}
```

A Saturn disc carries neither `stvgamepath` nor `stvgame`. Both calls refuse a
null path and a null romset, so both fail, and the `return -1` takes the whole
init down with it — the game never loads.

This guards all three on there actually being an ST-V game to init. ST-V
behaviour is unchanged.

Verified on Linux (`platform=unix`), Mesa 26.0.3 / Intel Arc, through the two
init paths a normal load takes. `YabauseRefreshInit()` is guarded the same way
for consistency but was not exercised at runtime.

Found while bringing Kronos up as a Kodi game add-on. Note this is separate from
`stvgame` being used uninitialised in `retro_load_game()`, which is already
fixed on this branch — with that fix in place, this is what stops the load.
